### PR TITLE
Detect Chrome WebView

### DIFF
--- a/src/getBrowser.js
+++ b/src/getBrowser.js
@@ -1,6 +1,8 @@
 import getVersion from './getBrowserVersion.js';
 
 export default function () {
+    const userAgent = navigator.userAgent;
+
     // Firefox 1.0+
     const isFirefox = typeof InstallTrigger !== 'undefined';
 
@@ -17,8 +19,10 @@ export default function () {
     // Edge 20+
     const isEdge = !isIE && !!window.StyleMedia;
 
-    // Chrome or Chromium 1+
-    const isChrome = !!window.chrome && !!window.chrome.loadTimes;
+    // Chrome, Chromium 1+ or Chrome WebView
+    const isChromeBrowser = !!window.chrome && !!window.chrome.loadTimes;
+    const isChromeWebView = /; wv/.test(userAgent) && /Chrome/.test(userAgent);
+    const isChrome = isChromeBrowser || isChromeWebView;
 
     const browser = isChrome
         ? 'chrome'
@@ -32,8 +36,7 @@ export default function () {
                         ? 'edge'
                         : false;
 
-    const version =
-        browser && getVersion[browser] ? getVersion[browser](navigator.userAgent) : false;
+    const version = browser && getVersion[browser] ? getVersion[browser](userAgent) : false;
 
     return { browser: browser, version: version };
 }


### PR DESCRIPTION
This PR addresses a bug present in all our chart embeds in at least some versions of Android WebView. The full description and analysis of the bug can be found here: https://www.notion.so/datawrapper/In-Android-webview-iframe-resizing-seems-to-cause-page-to-jump-to-Datawrapper-embed-on-load-d4fe6dfcd83543f2aa897a9a7a90bbc1.

**Bug description**

When loading a page with a chart in a WebView in an Android app, the page jumps down to the embed iframe.

**Why the bug occurs**

When a chart renders, we detect the browser and it's version in order to serve the correct polyfills (https://github.com/datawrapper/datawrapper/blob/master/src/render/index.js#L38). When a chart is loaded in a WebView, none of the tests return positive, so in the end the fallback `all.js` containing all polyfills is served (https://github.com/datawrapper/datawrapper/blob/fd23a9181c3cd4f5661924ff7360266e92382fc3/src/render/index.js#L55-L56). Loading a specific polyfill from `all.js` (`Event.focusin`) causes the bug to occur (I didn't check exactly what in this polyfill causes this behaviour, but I created a bundle of all polyfills which is the same as `all.js` minus `Event.focusin` and the bug disappeared).

**Proposed solution**

This PR solves the issue by adding detection for Android/Chrome WebView in `getBrowser.js`. An example of user agent on Android WebView can be found here: https://developer.chrome.com/multidevice/user-agent#webview_user_agent (under "WebView UA in Lollipop and Above"). If detected, we treat the WebView Chrome in the same way as Browser Chrome and attempt to determine the version, in order to serve the correct polyfills. This way, the `all.js` file containing the offending polyfill should not get served in the majority of Android WebView cases.

**Limitations**

- The detection will only work for Android Lollipop (5.0) and above (this was released in 2014 and should have considerable market share by now).
- `Event.focusin` is still present in the polyfills for Chrome versions 29 and below, so theoretically the bug might still occur if someone is using an ancient version of Android WebView. In practice, Chrome 30 was released in 2013 so by now no apps should be using it.

**To check**

I'd appreciate a check on regex usage here, let me know if there is a way to improve this:

```
const isChromeWebView = /; wv/.test(userAgent) && /Chrome/.test(userAgent);
```

Also, any other ideas on how to solve this problem are welcome - I know the solution in this PR isn't ideal, but I couldn't find a 100% reliable way of detecting Android WebView.