### PR TITLE
Add Samsung Internet as chrome alias

### DIFF
--- a/src/getBrowser.js
+++ b/src/getBrowser.js
@@ -25,7 +25,8 @@ export function getBrowser () {
     // Chrome, Chromium 1+ or Chrome WebView
     const isChromeBrowser = !!window.chrome && !!window.chrome.loadTimes;
     const isChromeWebView = /; wv/.test(userAgent) && /Chrome/.test(userAgent);
-    const isChrome = isChromeBrowser || isChromeWebView;
+    const isSamsungInternet = /SAMSUNG/.test(userAgent) && /Chrome/.test(userAgent);
+    const isChrome = isChromeBrowser || isChromeWebView || isSamsungInternet;
 
     const browser = isChrome
         ? 'chrome'


### PR DESCRIPTION
There's a browser called [Samsung Internet](https://en.wikipedia.org/wiki/Samsung_Internet) which is based on Chromium, though this wasn't previously recognized as such by our polyfills. This PR changes it so that we treat it like Chrome.