### PR TITLE
Identify HeadlessChrome as Chrome

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,0 @@
-{
-    "extends": ["standard"],
-    "rules": {
-        "indent": ["error", 4],
-        "semi": ["error", "always"]
-    }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8671,9 +8671,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
     },
     "pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -1,62 +1,64 @@
 {
-  "name": "@datawrapper/polyfills",
-  "version": "2.1.0",
-  "description": "",
-  "main": "dist/getBrowser.js",
-  "module": "dist/getBrowser.mjs",
-  "umd:main": "dist/getBrowser.umd.js",
-  "source": "src/getBrowser.js",
-  "files": [
-    "dist",
-    "polyfills"
-  ],
-  "scripts": {
-    "prepublishOnly": "npm test && npm run build",
-    "test": "ava",
-    "dev": "microbundle --watch",
-    "build": "microbundle --name=getBrowser",
-    "download": "node -r esm scripts/download-polyfills.js",
-    "upload": "make upload",
-    "lint": "healthier **/*.js",
-    "format": "prettier **/*.js --write && healthier **/*.js --fix"
-  },
-  "author": "Gregor Aisch",
-  "license": "ISC",
-  "devDependencies": {
-    "ava": "~3.10.1",
-    "babel-eslint": "~10.1.0",
-    "caniuse-api": "^3.0.0",
-    "esm": "~3.2.25",
-    "healthier": "~4.0.0",
-    "husky": "~4.2.5",
-    "lint-staged": "~10.2.11",
-    "lodash.range": "~3.2.0",
-    "microbundle": "~0.12.3",
-    "prettier": "~1.19.1",
-    "request": "~2.88.2",
-    "tap-xunit": "~2.4.1",
-    "useragent-generator": "~1.1.0"
-  },
-  "ava": {
-    "require": [
-      "esm"
-    ]
-  },
-  "prettier": {
-    "tabWidth": 4,
-    "semi": true,
-    "printWidth": 100,
-    "singleQuote": true
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
+    "name": "@datawrapper/polyfills",
+    "version": "2.1.0",
+    "description": "",
+    "main": "dist/getBrowser.js",
+    "module": "dist/getBrowser.mjs",
+    "umd:main": "dist/getBrowser.umd.js",
+    "source": "src/getBrowser.js",
+    "files": [
+        "dist",
+        "polyfills"
+    ],
+    "scripts": {
+        "prepublishOnly": "npm test && npm run build",
+        "test": "ava",
+        "dev": "microbundle --watch",
+        "build": "microbundle --name=getBrowser",
+        "download": "node -r esm scripts/download-polyfills.js",
+        "upload": "make upload",
+        "lint": "healthier **/*.js && prettier --check **/*.js",
+        "format": "healthier --fix **/*.js && prettier --write **/*.js"
+    },
+    "author": "Gregor Aisch",
+    "license": "ISC",
+    "devDependencies": {
+        "ava": "~3.10.1",
+        "babel-eslint": "~10.1.0",
+        "caniuse-api": "^3.0.0",
+        "esm": "~3.2.25",
+        "healthier": "~4.0.0",
+        "husky": "~4.2.5",
+        "lint-staged": "~10.2.11",
+        "lodash.range": "~3.2.0",
+        "microbundle": "~0.12.3",
+        "prettier": "^2.2.1",
+        "request": "~2.88.2",
+        "tap-xunit": "~2.4.1",
+        "useragent-generator": "~1.1.0"
+    },
+    "ava": {
+        "require": [
+            "esm"
+        ]
+    },
+    "prettier": {
+        "arrowParens": "avoid",
+        "printWidth": 100,
+        "semi": true,
+        "singleQuote": true,
+        "tabWidth": 4,
+        "trailingComma": "none"
+    },
+    "husky": {
+        "hooks": {
+            "pre-commit": "lint-staged"
+        }
+    },
+    "lint-staged": {
+        "*.js": [
+            "healthier",
+            "prettier --check"
+        ]
     }
-  },
-  "lint-staged": {
-    "*.js": [
-      "prettier --write",
-      "healthier --fix"
-    ]
-  }
 }

--- a/scripts/download-polyfills.js
+++ b/scripts/download-polyfills.js
@@ -8,7 +8,7 @@ const { getLatestStableBrowsers } = require('caniuse-api');
 
 const request = promisify(require('request'));
 
-export function getLatestVersionNumber (browser) {
+export function getLatestVersionNumber(browser) {
     return +getLatestStableBrowsers()
         .find(val => val.includes(browser))
         .split(' ')[1];
@@ -62,7 +62,7 @@ const availablePolyfills = {
     safari: []
 };
 
-async function load (key, ua) {
+async function load(key, ua) {
     console.log('loading', key);
     const { body } = await request(
         `https://cdn.polyfill.io/v3/polyfill.min.js?flags=gated&features=default,${features.join(
@@ -80,7 +80,7 @@ async function load (key, ua) {
     }
 }
 
-async function main () {
+async function main() {
     for (const [browser, ua] of browsers) {
         await load(browser, ua);
     }

--- a/src/getBrowser.js
+++ b/src/getBrowser.js
@@ -3,7 +3,7 @@ import polyfills from './availablePolyfills.js';
 
 export const availablePolyfills = polyfills;
 
-export function getBrowser () {
+export function getBrowser() {
     const userAgent = navigator.userAgent;
 
     // Firefox 1.0+
@@ -23,7 +23,8 @@ export function getBrowser () {
     const isEdge = !isIE && !!window.StyleMedia;
 
     // Chrome, Chromium 1+ or Chrome WebView
-    const isChromeBrowser = /HeadlessChrome/.test(userAgent) || !!window.chrome && !!window.chrome.loadTimes;
+    const isChromeBrowser =
+        /HeadlessChrome/.test(userAgent) || (!!window.chrome && !!window.chrome.loadTimes);
     const isChromeWebView = /; wv/.test(userAgent) && /Chrome/.test(userAgent);
     const isSamsungInternet = /SAMSUNG/.test(userAgent) && /Chrome/.test(userAgent);
     const isChrome = isChromeBrowser || isChromeWebView || isSamsungInternet;
@@ -31,14 +32,14 @@ export function getBrowser () {
     const browser = isChrome
         ? 'chrome'
         : isFirefox
-            ? 'firefox'
-            : isSafari
-                ? 'safari'
-                : isIE
-                    ? 'ie'
-                    : isEdge
-                        ? 'edge'
-                        : false;
+        ? 'firefox'
+        : isSafari
+        ? 'safari'
+        : isIE
+        ? 'ie'
+        : isEdge
+        ? 'edge'
+        : false;
 
     const version = browser && getVersion[browser] ? getVersion[browser](userAgent) : false;
 

--- a/src/getBrowser.js
+++ b/src/getBrowser.js
@@ -23,7 +23,7 @@ export function getBrowser () {
     const isEdge = !isIE && !!window.StyleMedia;
 
     // Chrome, Chromium 1+ or Chrome WebView
-    const isChromeBrowser = !!window.chrome && !!window.chrome.loadTimes;
+    const isChromeBrowser = /HeadlessChrome/.test(userAgent) || !!window.chrome && !!window.chrome.loadTimes;
     const isChromeWebView = /; wv/.test(userAgent) && /Chrome/.test(userAgent);
     const isSamsungInternet = /SAMSUNG/.test(userAgent) && /Chrome/.test(userAgent);
     const isChrome = isChromeBrowser || isChromeWebView || isSamsungInternet;

--- a/src/getBrowserVersion.js
+++ b/src/getBrowserVersion.js
@@ -1,4 +1,4 @@
-function getVersion (RE) {
+function getVersion(RE) {
     return function (userAgent) {
         const raw = userAgent.toLowerCase().match(RE);
         return raw ? parseInt(raw[1], 10) : false;


### PR DESCRIPTION
While going through server logs I noticed we ship `polyfills.all.js` to our very own render clients 🤦‍♂️

This is because we use `window.chrome` for detecting whether we're in Chrome, which isn't set in headless mode. This PR updates the check to also test the User Agent for `HeadlessChrome`, which is how it identifies itself.

Maybe this will have some positive impact on render clients in some way (maybe performance?)